### PR TITLE
Moved document eventlistener to sideNav

### DIFF
--- a/side-nav/side-nav.js
+++ b/side-nav/side-nav.js
@@ -46,9 +46,9 @@ class SideNav {
     this.sideNavEl.addEventListener('click', this.hideSideNav);
     this.sideNavContainerEl.addEventListener('click', this.blockClicks);
 
-    document.addEventListener('touchstart', this.onTouchStart);
-    document.addEventListener('touchmove', this.onTouchMove);
-    document.addEventListener('touchend', this.onTouchEnd);
+    this.sideNavEl.addEventListener('touchstart', this.onTouchStart);
+    this.sideNavEl.addEventListener('touchmove', this.onTouchMove);
+    this.sideNavEl.addEventListener('touchend', this.onTouchEnd);
   }
 
   onTouchStart (evt) {


### PR DESCRIPTION
I noticed that you bind the eventlistener to the document instead of the sideNav__container; I prefer the behaviour aswell, but I think binding to the sideNav is even more appropriate. This way everything is much nicer contained to just the elements inside sideNav.

Same as #21, which was closed by master branch removal. 
