### PR TITLE
Implement spa-serve

### DIFF
--- a/spa-serve/crosscompile.sh
+++ b/spa-serve/crosscompile.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+for target in darwin:amd64 linux:amd64 linux:386 linux:arm windows:amd64; do
+  echo "Compiling $target"
+  export GOOS=$(echo $target | cut -d: -f1) GOARCH=$(echo $target | cut -d: -f2)
+  bash -c "go build -o $(basename $(echo $PWD))_${GOOS}_${GOARCH} ."
+done

--- a/spa-serve/spa-serve.go
+++ b/spa-serve/spa-serve.go
@@ -1,0 +1,177 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func main() {
+	var (
+		listen = flag.Int("listen", 5000, "Port to listen on")
+		spa    = flag.String("spa", "index.html", "Page to deliver for an SPA")
+	)
+	flag.Parse()
+
+	generateCertificates("localhost")
+	fileServer := http.FileServer(http.Dir("."))
+	http.HandleFunc("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		delayString := r.FormValue("delay")
+		delay, err := strconv.Atoi(delayString)
+		if err == nil {
+			time.Sleep(time.Duration(delay) * time.Millisecond)
+		}
+
+		path := r.URL.Path
+		if _, err := os.Stat("." + path); err == nil {
+			fileServer.ServeHTTP(w, r)
+			return
+		}
+
+		spaContents, err := readSPAFile(*spa)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Could not read SPA file: %s", err), http.StatusInternalServerError)
+			return
+		}
+		w.Write(spaContents)
+	}))
+
+	log.Printf("Starting webserver on https://localhost:%d...", *listen)
+	err := http.ListenAndServeTLS(fmt.Sprintf(":%d", *listen), "cert.pem", "key.pem", nil)
+	log.Fatalf("Error starting webserver: %s", err)
+}
+
+var (
+	validFrom  = time.Now()
+	validFor   = 365 * 24 * time.Hour
+	isCA       = true
+	rsaBits    = 2048
+	ecdsaCurve = ""
+)
+
+func publicKey(priv interface{}) interface{} {
+	switch k := priv.(type) {
+	case *rsa.PrivateKey:
+		return &k.PublicKey
+	case *ecdsa.PrivateKey:
+		return &k.PublicKey
+	default:
+		return nil
+	}
+}
+
+func pemBlockForKey(priv interface{}) *pem.Block {
+	switch k := priv.(type) {
+	case *rsa.PrivateKey:
+		return &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(k)}
+	case *ecdsa.PrivateKey:
+		b, err := x509.MarshalECPrivateKey(k)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Unable to marshal ECDSA private key: %v", err)
+			os.Exit(2)
+		}
+		return &pem.Block{Type: "EC PRIVATE KEY", Bytes: b}
+	default:
+		return nil
+	}
+}
+
+func generateCertificates(host string) {
+	var priv interface{}
+	var err error
+	priv, err = rsa.GenerateKey(rand.Reader, rsaBits)
+	if err != nil {
+		log.Fatalf("failed to generate private key: %s", err)
+	}
+
+	var notBefore = validFrom
+	notAfter := notBefore.Add(validFor)
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		log.Fatalf("failed to generate serial number: %s", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Acme Co"},
+		},
+		NotBefore: notBefore,
+		NotAfter:  notAfter,
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	hosts := strings.Split(host, ",")
+	for _, h := range hosts {
+		if ip := net.ParseIP(h); ip != nil {
+			template.IPAddresses = append(template.IPAddresses, ip)
+		} else {
+			template.DNSNames = append(template.DNSNames, h)
+		}
+	}
+
+	if isCA {
+		template.IsCA = true
+		template.KeyUsage |= x509.KeyUsageCertSign
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, publicKey(priv), priv)
+	if err != nil {
+		log.Fatalf("Failed to create certificate: %s", err)
+	}
+
+	certOut, err := os.Create("cert.pem")
+	if err != nil {
+		log.Fatalf("failed to open cert.pem for writing: %s", err)
+	}
+	pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	certOut.Close()
+	log.Print("written cert.pem\n")
+
+	keyOut, err := os.OpenFile("key.pem", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		log.Print("failed to open key.pem for writing:", err)
+		return
+	}
+	pem.Encode(keyOut, pemBlockForKey(priv))
+	keyOut.Close()
+	log.Print("written key.pem\n")
+}
+
+func readSPAFile(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return ioutil.ReadAll(f)
+}


### PR DESCRIPTION
`spa-serve` is a fork of [`simplehttp2server`](https://github.com/GoogleChrome/simplehttp2server) that has support for serving SPAs and can add artificial delays to requests.
## Usage

Serving the current directory over HTTP/2, serving `index.html` instead of 404s

```
$ spa-serve
2016/06/28 12:40:05 written cert.pem
2016/06/28 12:40:05 written key.pem
2016/06/28 12:40:05 Starting webserver on https://localhost:5000...
```
## Delays

The response to a request can be artificially delayed by 500ms by adding `?delay=500` to the request. Other numbers work too! Magic.
## Binaries
- [Mac OS X](https://f.surma.link/spa-serve/spa-serve_darwin_amd64)
- [Linux amd64](https://f.surma.link/spa-serve/spa-serve_linux_amd64)
- [Linux ARM](https://f.surma.link/spa-serve/spa-serve_linux_arm)
- [Windows](https://f.surma.link/spa-serve/spa-serve_windows_amd64)
