### PR TITLE
Add role="feed" to infinite scroll container, inset focus ring.

### DIFF
--- a/infinite-scroller/index.html
+++ b/infinite-scroller/index.html
@@ -74,6 +74,7 @@ limitations under the License.
   <script src="stats.min.js"></script>
   <script src="scripts/infinite-scroll.js"></script>
   <script src="scripts/messages.js"></script>
+  <script src="scripts/focus-attributes.js"></script>
   <script>
 var INIT_TIME = new Date().getTime();
 
@@ -176,11 +177,13 @@ function numDomNodes(node) {
 }
 
 document.addEventListener('DOMContentLoaded', function() {
+  var chatTimeline = document.querySelector('#chat-timeline');
   window.scroller =
     new InfiniteScroller(
-      document.querySelector('#chat-timeline'),
+      chatTimeline,
       new ContentSource()
     );
+  new FocusAttributes(chatTimeline);
 
   var stats = new Stats();
   var domPanel = new Stats.Panel('DOM Nodes', '#0ff', '#002');

--- a/infinite-scroller/index.html
+++ b/infinite-scroller/index.html
@@ -68,7 +68,7 @@ limitations under the License.
       </div>
     </li>
   </div>
-  <ul id="chat-timeline">
+  <ul id="chat-timeline" role="feed" tabindex="0">
   </ul>
   <script src="es6-promise.js"></script>
   <script src="stats.min.js"></script>

--- a/infinite-scroller/scripts/focus-attributes.js
+++ b/infinite-scroller/scripts/focus-attributes.js
@@ -1,0 +1,68 @@
+(function(scope) {
+
+
+/**
+ * Construct a component which adds `data-focus` hint attributes to an element.
+ *
+ * @constructor
+ * @param {Element} element The element which will be annotated with a
+ *     data-focus attribute on interaction.
+ */
+scope.FocusAttributes = function(element) {
+  this.element_ = element;
+  this.bindMethods_();
+  this.addEventListeners_();
+};
+
+
+scope.FocusAttributes.prototype = {
+  /**
+   * Add blur, focus and mousedown event listeners.
+   * @private
+   */
+  addEventListeners_: function() {
+    this.element_.addEventListener('blur', this.onBlur_.bind(this));
+    this.element_.addEventListener('focus', this.onFocus_.bind(this));
+    this.element_.addEventListener('mousedown', this.onMouseDown_.bind(this));
+  },
+
+  /**
+   * Bind methods to this instance of FocusAttributes.
+   * @private
+   */
+  bindMethods_: function() {
+    this.onBlur_ = this.onBlur_.bind(this);
+    this.onFocus_ = this.onFocus_.bind(this);
+    this.onMouseDown_ = this.onMouseDown_.bind(this);
+  },
+
+  /**
+   * Remove the data attr on blur.
+   * @private
+   */
+  onBlur_: function() {
+    this.element_.removeAttribute('data-focus');
+  },
+
+  /**
+   * Set the data attr to `keyboard` on focus, if it doesn't exist already.
+   * @private
+   */
+  onFocus_: function() {
+    if (this.element_.hasAttribute('data-focus'))
+      return;
+
+    this.element_.setAttribute('data-focus', 'keyboard');
+  },
+
+  /**
+   * Set the data attribute to `mouse` on mousedown.
+   * @private
+   */
+  onMouseDown_: function() {
+    this.element_.setAttribute('data-focus', 'mouse');
+  }
+};
+
+
+})(self);

--- a/infinite-scroller/styles/messages.css
+++ b/infinite-scroller/styles/messages.css
@@ -4,6 +4,7 @@
   overflow-x: hidden;
   overflow-y: scroll;
   -webkit-overflow-scrolling: touch;
+  outline-offset: -.2em;
   width: 100%;
   height: 100%;
   position: absolute;
@@ -11,8 +12,8 @@
   contain: layout;
 }
 
-#chat-timeline:focus {
-  outline-offset: -.2em;
+[data-focus="mouse"] {
+  outline: none;
 }
 
 .chat-item {

--- a/infinite-scroller/styles/messages.css
+++ b/infinite-scroller/styles/messages.css
@@ -11,6 +11,10 @@
   contain: layout;
 }
 
+#chat-timeline:focus {
+  outline-offset: -.2em;
+}
+
 .chat-item {
   display: flex;
   padding: 10px 0;


### PR DESCRIPTION
Implements issue #37.

I’m aiming to improve accessibility of the infinite scroller by adding `role="feed"` and `tabindex="0"` to the container element. I’ve also changed the focus ring to be inset for improved visibility (it was always there, just rendered outside the viewport.)
