### PR TITLE
FIX: Return positive value for negative modulo

### DIFF
--- a/accordion/sc-accordion.js
+++ b/accordion/sc-accordion.js
@@ -79,7 +79,7 @@ class SCAccordion extends HTMLElement {
       //   index = this._panes.length - 1;
       // }
 
-      index %= this._panes.length;
+      index = (index + this._panes.length) % this._panes.length;
 
       panesArray[index].header.focus();
     });


### PR DESCRIPTION
There is a _problem_ with modulo of negative number. `-1 % 4` will return `-1`.

In the accordion, we could not then key up/left and loop over the panes so I added the number of panes to it for the modulo to, as expected, loop over the list.
