### PR TITLE
Make the background opacity change as the user drags the sidenav.

### DIFF
--- a/side-nav/side-nav.js
+++ b/side-nav/side-nav.js
@@ -103,6 +103,7 @@ class SideNav {
 
     const translateX = Math.min(0, this.currentX - this.startX);
     this.sideNavContainerEl.style.transform = '';
+    this.sideNavEl.style.removeProperty('--current-opacity');
 
     if (translateX < 0) {
       this.hideSideNav();
@@ -117,6 +118,8 @@ class SideNav {
 
     const translateX = Math.min(0, this.currentX - this.startX);
     this.sideNavContainerEl.style.transform = `translateX(${translateX}px)`;
+    this.sideNavEl.style.setProperty('--current-opacity',
+        Math.min(Math.max(this.currentX / this.startX, 0), 1));
   }
 
   blockClicks (evt) {

--- a/side-nav/styles.css
+++ b/side-nav/styles.css
@@ -72,8 +72,8 @@ html, body {
   height: 100%;
   background: rgba(0,0,0,0.4);
   opacity: 0;
+  opacity: var(--current-opacity, 0);
   will-change: opacity;
-  transition: opacity 0.3s cubic-bezier(0,0,0.3,1);
 }
 
 .side-nav__container {
@@ -89,6 +89,10 @@ html, body {
   will-change: transform;
 }
 
+.side-nav--animatable::before {
+  transition: opacity 0.3s cubic-bezier(0,0,0.3,1);
+}
+
 .side-nav--animatable .side-nav__container {
   transition: transform 0.13s cubic-bezier(0,0,0.3,1);
 }
@@ -99,6 +103,7 @@ html, body {
 
 .side-nav--visible::before {
   opacity: 1;
+  opacity: var(--current-opacity, 1);
 }
 
 .side-nav--visible .side-nav__container {


### PR DESCRIPTION
This is a progressive enhancement for browsers with custom properties.

Custom properties are needed since we have no way of styling pseudo-elements from JS; they allow us to get around this restriction by setting the custom property on the parent and having the pseudo-element just use it.

@surma @paullewis PTAL!
