### PR TITLE
Horizontal scrollbar on "3D Card Flip"

### DIFF
--- a/3d-card-flip/styles.css
+++ b/3d-card-flip/styles.css
@@ -25,6 +25,8 @@ html, body {
   width: 100%;
   height: 100%;
   font-family: Arial, Helvetica, sans-serif;
+  overflow-x: hidden;
+  overflow-y: scroll;
 }
 
 body {
@@ -52,6 +54,7 @@ sc-card .back {
   align-items: center;
   justify-content: center;
   border-radius: 3px;
+  overflow: hidden;
 }
 
 sc-card button {

--- a/3d-card-flip/styles.css
+++ b/3d-card-flip/styles.css
@@ -25,8 +25,6 @@ html, body {
   width: 100%;
   height: 100%;
   font-family: Arial, Helvetica, sans-serif;
-  overflow-x: hidden;
-  overflow-y: scroll;
 }
 
 body {
@@ -34,6 +32,8 @@ body {
   align-items: center;
   justify-content: center;
   background: #E2E2E2;
+  overflow-x: hidden;
+  overflow-y: scroll;
 }
 
 sc-card {


### PR DESCRIPTION
<br>
<strong>See issue #46 </strong>
<br>

<hr>

<br>
Wild horizontal scrollbar appears because of `text-indent: -10000px;` on the flip buttons.

**Possible Solution:**
Add overflow hidden to the .front and .back div

``` css
sc-card .front,
sc-card .back {
  backface-visibility: hidden;
  position: absolute;
  width: 100%;
  height: 100%;
  display: flex;
  align-items: center;
  justify-content: center;
  border-radius: 3px;
  overflow: hidden; /* <- here */
}
```

**Side effect:**
On certain (medium sized) displays, there are now no scrollbars. But if the card reaches its max size when animating and the cards gets now bigger than the viewport a vertical scrollbar appears (only for the short time the card is bigger than the viewport). This leads to a "jumping/jiggle effect" because the viewport is now narrower (width of scrollbar) than before.
**Possible Solution:**
Always show the horizontal scrollbar.

``` css
body {
  overflow-x: hidden;
  overflow-y: scroll;
}
```
