### PR TITLE
Fix sc-view to show HTML

### DIFF
--- a/router-advanced/about/index.html
+++ b/router-advanced/about/index.html
@@ -20,9 +20,9 @@ limitations under the License.
   <title>Router</title>
   <link rel="stylesheet" href="/static/superstyles.css">
   <link rel="preload" href="/">
-  <link rel="preload" href="/about/">
+  <!--<link rel="preload" href="/about/">-->
   <link rel="preload" href="/contact/">
-  <!--<link rel="preload" href="/misc/">-->
+  <link rel="preload" href="/misc/">
 </head>
 <body>
   <nav>

--- a/router-advanced/about/index.html
+++ b/router-advanced/about/index.html
@@ -35,10 +35,7 @@ limitations under the License.
   </nav>
 
   <sc-view remote class="view-home" route="^/$"></sc-view>
-  <sc-view class="view-about visible" route="^/about/(.*)">
-    <h1>About</h1>
-    <p>This is the about page.</p>
-  </sc-view>
+  <sc-view class="view-about visible" route="^/about/(.*)"><div>About</div></sc-view>
   <sc-view remote class="view-contact" route="^/contact/(.*)"></sc-view>
   <sc-view remote class="view-misc" route="^/misc/(.*)"></sc-view>
 

--- a/router-advanced/about/index.html
+++ b/router-advanced/about/index.html
@@ -35,7 +35,10 @@ limitations under the License.
   </nav>
 
   <sc-view remote class="view-home" route="^/$"></sc-view>
-  <sc-view class="view-about visible" route="^/about/(.*)">About</sc-view>
+  <sc-view class="view-about visible" route="^/about/(.*)">
+    <h1>About</h1>
+    <p>This is the about page.</p>
+  </sc-view>
   <sc-view remote class="view-contact" route="^/contact/(.*)"></sc-view>
   <sc-view remote class="view-misc" route="^/misc/(.*)"></sc-view>
 

--- a/router-advanced/index.html
+++ b/router-advanced/index.html
@@ -34,7 +34,10 @@ limitations under the License.
     </ul>
   </nav>
 
-  <sc-view class="view-home visible" route="^/$">Home</sc-view>
+  <sc-view class="view-home visible" route="^/$">
+    <h1>Home</h1>
+    <p>This is the Home page.</p>
+  </sc-view>
   <sc-view remote class="view-about" route="^/about/(.*)"></sc-view>
   <sc-view remote class="view-contact" route="^/contact/(.*)"></sc-view>
   <sc-view remote class="view-misc" route="^/misc/(.*)"></sc-view>

--- a/router-advanced/index.html
+++ b/router-advanced/index.html
@@ -19,7 +19,7 @@ limitations under the License.
   <meta name="theme-color" content="#FF00FF">
   <title>Router</title>
   <link rel="stylesheet" href="/static/superstyles.css">
-  <link rel="preload" href="/">
+  <!--<link rel="preload" href="/">-->
   <link rel="preload" href="/about/">
   <link rel="preload" href="/contact/">
   <!--<link rel="preload" href="/misc/">-->

--- a/router-advanced/index.html
+++ b/router-advanced/index.html
@@ -34,10 +34,11 @@ limitations under the License.
     </ul>
   </nav>
 
-  <sc-view remote class="view-home" route="^/$"></sc-view>
-  <sc-view class="view-about visible" route="^/about/(.*)">
-    <h1>About</h1>
+  <sc-view class="view-home visible" route="^/$">
+    <h1>Home</h1>
     <p>This is the about page.</p>
+  </sc-view>
+  <sc-view remote class="view-about" route="^/about/(.*)">
   </sc-view>
   <sc-view remote class="view-contact" route="^/contact/(.*)"></sc-view>
   <sc-view remote class="view-misc" route="^/misc/(.*)"></sc-view>

--- a/router-advanced/index.html
+++ b/router-advanced/index.html
@@ -35,8 +35,7 @@ limitations under the License.
   </nav>
 
   <sc-view class="view-home visible" route="^/$"><div>Home</div></sc-view>
-  <sc-view remote class="view-about" route="^/about/(.*)">
-  </sc-view>
+  <sc-view remote class="view-about" route="^/about/(.*)"></sc-view>
   <sc-view remote class="view-contact" route="^/contact/(.*)"></sc-view>
   <sc-view remote class="view-misc" route="^/misc/(.*)"></sc-view>
 

--- a/router-advanced/index.html
+++ b/router-advanced/index.html
@@ -19,10 +19,10 @@ limitations under the License.
   <meta name="theme-color" content="#FF00FF">
   <title>Router</title>
   <link rel="stylesheet" href="/static/superstyles.css">
-  <!--<link rel="preload" href="/">-->
+  <link rel="preload" href="/">
   <link rel="preload" href="/about/">
   <link rel="preload" href="/contact/">
-  <link rel="preload" href="/misc/">
+  <!--<link rel="preload" href="/misc/">-->
 </head>
 <body>
   <nav>
@@ -34,11 +34,11 @@ limitations under the License.
     </ul>
   </nav>
 
-  <sc-view class="view-home visible" route="^/$">
-    <h1>Home</h1>
-    <p>This is the Home page.</p>
+  <sc-view remote class="view-home" route="^/$"></sc-view>
+  <sc-view class="view-about visible" route="^/about/(.*)">
+    <h1>About</h1>
+    <p>This is the about page.</p>
   </sc-view>
-  <sc-view remote class="view-about" route="^/about/(.*)"></sc-view>
   <sc-view remote class="view-contact" route="^/contact/(.*)"></sc-view>
   <sc-view remote class="view-misc" route="^/misc/(.*)"></sc-view>
 

--- a/router-advanced/index.html
+++ b/router-advanced/index.html
@@ -34,10 +34,7 @@ limitations under the License.
     </ul>
   </nav>
 
-  <sc-view class="view-home visible" route="^/$">
-    <h1>Home</h1>
-    <p>This is the about page.</p>
-  </sc-view>
+  <sc-view class="view-home visible" route="^/$"><div>Home</div></sc-view>
   <sc-view remote class="view-about" route="^/about/(.*)">
   </sc-view>
   <sc-view remote class="view-contact" route="^/contact/(.*)"></sc-view>

--- a/router-advanced/index.html
+++ b/router-advanced/index.html
@@ -22,7 +22,7 @@ limitations under the License.
   <!--<link rel="preload" href="/">-->
   <link rel="preload" href="/about/">
   <link rel="preload" href="/contact/">
-  <!--<link rel="preload" href="/misc/">-->
+  <link rel="preload" href="/misc/">
 </head>
 <body>
   <nav>

--- a/router-advanced/static/sc-view.js
+++ b/router-advanced/static/sc-view.js
@@ -48,13 +48,8 @@ class SCView extends HTMLElement {
       const newDoc = evt.target.response;
       const newView = newDoc.querySelector('sc-view.visible');
 
-      // Copy in the child nodes from the parent.
-      newView.childNodes.forEach(node => {
-        this._view.appendChild(node);
-      });
-
       // Add the fragment to the page.
-      this.appendChild(this._view);
+      this.innerHTML = newView.innerHTML;
 
       // Clear the timeout and remove the spinner if needed.
       clearTimeout(spinnerTimeout);

--- a/router-advanced/static/sc-view.js
+++ b/router-advanced/static/sc-view.js
@@ -48,8 +48,13 @@ class SCView extends HTMLElement {
       const newDoc = evt.target.response;
       const newView = newDoc.querySelector('sc-view.visible');
 
+      // Copy in the child nodes from the parent.
+      while(newView.firstChild) {
+         this._view.appendChild(newView.firstChild);
+      }
+
       // Add the fragment to the page.
-      this.innerHTML = newView.innerHTML;
+      this.appendChild(this._view);
 
       // Clear the timeout and remove the spinner if needed.
       clearTimeout(spinnerTimeout);


### PR DESCRIPTION
sc-view.js has been updated to allow HTML to be shown.  This is done by using `this.innerHTML = newView.innerHTML;` instead of running through newView.childNodes and appending them to this._view.
