### PR TITLE
Update superstyles.css

### DIFF
--- a/router-advanced/static/superstyles.css
+++ b/router-advanced/static/superstyles.css
@@ -44,6 +44,9 @@ sc-view {
   justify-content: center;
   align-items: center;
   color: white;
+  display:block;
+  zoom: 1;
+  overflow:hidden;
 }
 
 sc-view.visible {


### PR DESCRIPTION
In order for Safari and Firefox to behave similar to Chrome, where the non-visible <sc-view>'s move out of the way to allow the visible <sc-view> to take up the whole area, `display:block;` and `overflow:hidden;` must be added.  For IE to behave the same `zoom: 1;` must be added.
