### PR TITLE
Pointer event on ripple

### DIFF
--- a/flip-switch/flip-switch.html
+++ b/flip-switch/flip-switch.html
@@ -108,11 +108,13 @@
       transition: transform 0.6s cubic-bezier(0.6, 0, 0.3, 1);
       transform: translate(-50%, -50%) scale(0);
       border-radius: 50%;
+      pointer-events: none;
       will-change: transform;
     }
 
     .ripple.expanded {
       transform: translate(-50%, -50%) scale(1);
+      pointer-events: auto;
     }
 
     .shadow2px,


### PR DESCRIPTION
You don't want the user to press the ripple while it is closing and open everything up again.
