### PR TITLE
Fix parallax after resize - fixes #68

### DIFF
--- a/parallax/scripts/parallax.js
+++ b/parallax/scripts/parallax.js
@@ -74,7 +74,6 @@ function initializeParallax(clip) {
 
     parallaxDetails.push({'node': parallax[i],
                           'top': parallax[i].offsetTop,
-                          'height': parallax[i].offsetHeight,
                           'sticky': !!sticky,
                           'nextCover': nextCover,
                           'previousCover': previousCover});
@@ -119,12 +118,13 @@ function onResize(details) {
     var parallaxStart = previousCover ? (previousCover.offsetTop + previousCover.offsetHeight) : 0;
     var scrollbarWidth = details[i].sticky ? 0 : clip.offsetWidth - clip.clientWidth;
     var parallaxElem = details[i].sticky ? container : clip;
+    var height = details[i].node.offsetHeight;
     var depth = 0;
     if (rate) {
       depth = 1 - (1 / rate);
     } else {
       var parallaxEnd = nextCover ? nextCover.offsetTop : container.offsetHeight;
-      depth = (details[i].height - parallaxEnd + parallaxStart) / (details[i].height - clip.clientHeight);
+      depth = (height - parallaxEnd + parallaxStart) / (height - clip.clientHeight);
     }
     if (details[i].sticky)
       depth = 1.0 / depth;
@@ -135,8 +135,8 @@ function onResize(details) {
     var dx = scrollbarWidth * (scale - 1);
     // Offset for the position within the container.
     var dy = details[i].sticky ?
-        -(clip.scrollHeight - parallaxStart - details[i].height) * (1 - scale) :
-        (parallaxStart - depth * (details[i].height - clip.clientHeight)) * scale;
+        -(clip.scrollHeight - parallaxStart - height) * (1 - scale) :
+        (parallaxStart - depth * (height - clip.clientHeight)) * scale;
 
     details[i].node.style.transform = 'scale(' + (1 - depth) + ') translate3d(' + dx + 'px, ' + dy + 'px, ' + depth + 'px)';
   }


### PR DESCRIPTION
We were caching the height of the parallax nodes but this can change based on the relayout after resize so we need to use the new height of the nodes.