### PR TITLE
Clip animation without between-frame artifacts

### DIFF
--- a/animated-clip/index.html
+++ b/animated-clip/index.html
@@ -79,25 +79,25 @@ limitations under the License.
     .menu--expanded {
       animation-name: menuExpandAnimation;
       animation-duration: 0.2s;
-      animation-timing-function: linear;
+      animation-timing-function: step-end;
     }
 
     .menu__contents--expanded {
       animation-name: menuExpandContentsAnimation;
       animation-duration: 0.2s;
-      animation-timing-function: linear;
+      animation-timing-function: step-end;
     }
 
     .menu--collapsed {
       animation-name: menuCollapseAnimation;
       animation-duration: 0.2s;
-      animation-timing-function: linear;
+      animation-timing-function: step-end;
     }
 
     .menu__contents--collapsed {
       animation-name: menuCollapseContentsAnimation;
       animation-duration: 0.2s;
-      animation-timing-function: linear;
+      animation-timing-function: step-end;
     }
 
   </style>

--- a/animated-clip/index.html
+++ b/animated-clip/index.html
@@ -28,15 +28,20 @@ limitations under the License.
       pointer-events: none;
       transform-origin: top left;
       overflow: hidden;
+      contain: content;
       border-radius: 3px;
       box-shadow: 0 3px 3px rgba(0, 0, 0, 0.4);
       background: #FFF;
       will-change: transform;
+      animation-duration: 0.2s;
+      animation-timing-function: step-end;
     }
 
     .menu__contents {
       transform-origin: top left;
       will-change: transform;
+      animation-duration: 0.2s;
+      animation-timing-function: step-end;
     }
 
     .menu__toggle {
@@ -78,26 +83,18 @@ limitations under the License.
 
     .menu--expanded {
       animation-name: menuExpandAnimation;
-      animation-duration: 0.2s;
-      animation-timing-function: step-end;
     }
 
     .menu__contents--expanded {
       animation-name: menuExpandContentsAnimation;
-      animation-duration: 0.2s;
-      animation-timing-function: step-end;
     }
 
     .menu--collapsed {
       animation-name: menuCollapseAnimation;
-      animation-duration: 0.2s;
-      animation-timing-function: step-end;
     }
 
     .menu__contents--collapsed {
       animation-name: menuCollapseContentsAnimation;
-      animation-duration: 0.2s;
-      animation-timing-function: step-end;
     }
 
   </style>

--- a/animated-clip/index.html
+++ b/animated-clip/index.html
@@ -33,14 +33,15 @@ limitations under the License.
       box-shadow: 0 3px 3px rgba(0, 0, 0, 0.4);
       background: #FFF;
       will-change: transform;
-      animation-duration: 0.2s;
+      animation-duration: 200ms;
       animation-timing-function: step-end;
     }
 
     .menu__contents {
       transform-origin: top left;
       will-change: transform;
-      animation-duration: 0.2s;
+      contain: content;
+      animation-duration: 200ms;
       animation-timing-function: step-end;
     }
 

--- a/animated-clip/menu.js
+++ b/animated-clip/menu.js
@@ -111,11 +111,7 @@ class Menu {
       .then(frame => {f2 = frame; return rafPromise();})
       .then(_ => {
         const ft = f2 - f1;
-<<<<<<< HEAD
         const fps = Math.ceil(1000 / ft);
-=======
-        const fps = Math.ceil(1 / ft * 1000);
->>>>>>> deb9b051634447ca1839a9a0526c4497069be8ff
         this._refreshRate = fps;
         this._frameTime = ft;
         console.log(`Refresh rate should be ${fps}Hz`);

--- a/animated-clip/menu.js
+++ b/animated-clip/menu.js
@@ -99,27 +99,30 @@ class Menu {
   }
 
   _getRefreshRate() {
+    const rafPromise = _ => new Promise(requestAnimationFrame);
+    const idlePromise = _ => new Promise(requestIdleCallback);
+
+    let f1, f2;
+
     return new Promise(resolve => {
-      requestIdleCallback(_ => {
-        requestAnimationFrame(_ => {
-          requestAnimationFrame(f1 => {
-            requestAnimationFrame(f2 => {
-              const ft = f2 - f1;
-              const fps = Math.ceil(1 / ft * 1000);
-              this._refreshRate = fps;
-              this._frameTime = ft;
-              console.log(`Refresh rate should be ${fps}Hz`);
-              resolve();
-            });
-          });
-        });
+      idlePromise()
+      .then(_ => rafPromise())
+      .then(frame => {f1 = frame; return rafPromise();})
+      .then(frame => {f2 = frame; return rafPromise();})
+      .then(_ => {
+        const ft = f2 - f1;
+        const fps = Math.ceil(1000 / ft);
+        this._refreshRate = fps;
+        this._frameTime = ft;
+        console.log(`Refresh rate should be ${fps}Hz`);
+        resolve();
       });
     });
   }
 
   _getDuration() {
-    const duration = window.getComputedStyle(this._menu).animationDuration;
-    this._duration = duration.replace(/[^0-9$.,]/g, '') * 1000;
+    this._duration = window.getComputedStyle(this._menu).animationDuration
+      .slice(0, -1) * 1000;
   }
 
   _addEventListeners () {

--- a/animated-clip/menu.js
+++ b/animated-clip/menu.js
@@ -26,6 +26,7 @@ class Menu {
 
     this._expanded = true;
     this._animate = false;
+    this._refreshRate = 60;
     this._collapsed;
 
     this.expand = this.expand.bind(this);
@@ -38,6 +39,8 @@ class Menu {
 
     this.collapse();
     this.activate();
+
+    this._getRefreshRate();
   }
 
   activate () {
@@ -57,7 +60,7 @@ class Menu {
 
     this._menu.style.transform = `scale(${x}, ${y})`;
     this._menuContents.style.transform = `scale(${invX}, ${invY})`;
-    
+
     if (!this._animate) {
       return;
     }
@@ -73,7 +76,7 @@ class Menu {
 
     this._menu.style.transform = `scale(1, 1)`;
     this._menuContents.style.transform = `scale(1, 1)`;
-      
+
     if (!this._animate) {
       return;
     }
@@ -88,6 +91,20 @@ class Menu {
     }
 
     this.expand();
+  }
+
+  _getRefreshRate() {
+    window.requestIdleCallback(() => {
+      requestAnimationFrame(f1 => {
+        requestAnimationFrame(f2 => {
+          const ft = f2 - f1;
+          const fps = Math.round(1 / ft * 1000);
+          console.log(`${fps} Hz`);
+          if (fps <= 60) return;
+          this._refreshRate = fps;
+        });
+      });
+    });
   }
 
   _addEventListeners () {
@@ -136,8 +153,8 @@ class Menu {
     const menuExpandContentsAnimation = [];
     const menuCollapseAnimation = [];
     const menuCollapseContentsAnimation = [];
-    for (let i = 0; i <= 100; i++) {
-      const step = this._ease(i/100);
+    for (let i = 0; i <= 100; i+= (100 / this._refreshRate)) {
+      const step = this._ease(i / 100);
       const startX = this._collapsed.x;
       const startY = this._collapsed.y;
       const endX = 1;
@@ -176,7 +193,7 @@ class Menu {
       @keyframes menuExpandContentsAnimation {
         ${menuExpandContentsAnimation.join('')}
       }
-      
+
       @keyframes menuCollapseAnimation {
         ${menuCollapseAnimation.join('')}
       }
@@ -192,11 +209,11 @@ class Menu {
   _append ({
         i,
         step,
-        startX, 
-        startY, 
-        endX, 
-        endY, 
-        outerAnimation, 
+        startX,
+        startY,
+        endX,
+        endY,
+        outerAnimation,
         innerAnimation}=opts) {
 
     const xScale = startX + (endX - startX) * step;

--- a/animated-clip/menu.js
+++ b/animated-clip/menu.js
@@ -99,27 +99,30 @@ class Menu {
   }
 
   _getRefreshRate() {
+    const rafPromise = _ => new Promise(requestAnimationFrame);
+    const idlePromise = _ => new Promise(requestIdleCallback);
+
+    let f1, f2;
+
     return new Promise(resolve => {
-      requestIdleCallback(_ => {
-        requestAnimationFrame(_ => {
-          requestAnimationFrame(f1 => {
-            requestAnimationFrame(f2 => {
-              const ft = f2 - f1;
-              const fps = Math.ceil(1 / ft * 1000);
-              this._refreshRate = fps;
-              this._frameTime = ft;
-              console.log(`Refresh rate should be ${fps}Hz`);
-              resolve();
-            });
-          });
-        });
+      idlePromise()
+      .then(_ => rafPromise())
+      .then(frame => {f1 = frame; return rafPromise();})
+      .then(frame => {f2 = frame; return rafPromise();})
+      .then(_ => {
+        const ft = f2 - f1;
+        const fps = Math.ceil(1 / ft * 1000);
+        this._refreshRate = fps;
+        this._frameTime = ft;
+        console.log(`Refresh rate should be ${fps}Hz`);
+        resolve();
       });
     });
   }
 
   _getDuration() {
-    const duration = window.getComputedStyle(this._menu).animationDuration;
-    this._duration = duration.replace(/[^0-9$.,]/g, '') * 1000;
+    this._duration = window.getComputedStyle(this._menu).animationDuration
+      .slice(0, -1) * 1000;
   }
 
   _addEventListeners () {

--- a/animated-clip/menu.js
+++ b/animated-clip/menu.js
@@ -99,7 +99,6 @@ class Menu {
         requestAnimationFrame(f2 => {
           const ft = f2 - f1;
           const fps = Math.round(1 / ft * 1000);
-          console.log(`${fps} Hz`);
           if (fps <= 60) return;
           this._refreshRate = fps;
         });

--- a/animated-clip/menu.js
+++ b/animated-clip/menu.js
@@ -28,24 +28,23 @@ class Menu {
     this._animate = false;
     this._duration;
     this._refreshRate;
+    this._frameTime;
     this._collapsed;
 
     this.expand = this.expand.bind(this);
     this.collapse = this.collapse.bind(this);
     this.toggle = this.toggle.bind(this);
 
-    window.requestIdleCallback(() => {
-      // promisify to give it some breathing space
-      this._getRefreshRate()
-        .then(() => {
-          this._calculateScales();
-          this._getDuration();
-          this._createEaseAnimations();
-          this._addEventListeners();
+    // promisify to give it some breathing space
+    this._getRefreshRate()
+      .then(_ => {
+        this._calculateScales();
+        this._getDuration();
+        this._createEaseAnimations();
+        this._addEventListeners();
 
-          this.collapse();
-          this.activate();
-      });
+        this.collapse();
+        this.activate();
     });
   }
 
@@ -101,14 +100,17 @@ class Menu {
 
   _getRefreshRate() {
     return new Promise(resolve => {
-      requestAnimationFrame(() => {
-        requestAnimationFrame(f1 => {
-          requestAnimationFrame(f2 => {
-            const ft = f2 - f1;
-            const fps = Math.round(1 / ft * 1000);
-            this._refreshRate = fps;
-            this._frameTime = ft;
-            resolve();
+      requestIdleCallback(_ => {
+        requestAnimationFrame(_ => {
+          requestAnimationFrame(f1 => {
+            requestAnimationFrame(f2 => {
+              const ft = f2 - f1;
+              const fps = Math.ceil(1 / ft * 1000);
+              this._refreshRate = fps;
+              this._frameTime = ft;
+              console.log(`Refresh rate should be ${fps}Hz`);
+              resolve();
+            });
           });
         });
       });
@@ -167,7 +169,7 @@ class Menu {
     const menuCollapseAnimation = [];
     const menuCollapseContentsAnimation = [];
 
-    const frameIncrement = 100 / Math.round(this._duration / this._frameTime);
+    const frameIncrement = 100 / Math.ceil(this._duration / this._frameTime);
 
     for (let i = 0; i <= 100; i+= frameIncrement) {
       const step = this._ease(i / 100);


### PR DESCRIPTION
A followup on https://twitter.com/ChromiumDev/status/845402027362521088

I added 2 raf-s to figure out the refresh rate of the device in order to accomodate varying refresh rates. It's wrapped in a `requestIdleCallback` and promisified to give the thread breathing room for accurate detection.
The animation is then defined per frame and uses `animation-timing-function: step-end` to only render the those needed.

In theory, this approach _should_ not cause mid-frame artifacts, generates ~1/10th of the frames for usual ~200-ish durations and is a bit fancier. Should be easier processing wise as well.