### PR TITLE
Fixed an error by changing a naïve condition

### DIFF
--- a/custom-scrollbar/scrollbar.js
+++ b/custom-scrollbar/scrollbar.js
@@ -1,18 +1,18 @@
 (function(scope) {
   var dragging = false;
   var lastY = 0;
-
+  
   function dragStart(event) {
     dragging = true;
     this.style.pointerEvents = 'none';
     this.style.userSelect = 'none';
 
-    lastY = event.clientY || event.touches[0].clientY;
+    lastY = (event.clientY || event.clientY === 0) ? event.clientY : event.touches[0].clientY);
   }
 
   function dragMove(event) {
     if (!dragging) return;
-    var clientY = event.clientY || event.touches[0].clientY;
+    var clientY = (event.clientY || event.clientY === 0) ? event.clientY : event.touches[0].clientY);
     this.scrollTop += (clientY - lastY)/this.thumb.scaling;
     lastY = clientY;
     event.preventDefault();

--- a/custom-scrollbar/scrollbar.js
+++ b/custom-scrollbar/scrollbar.js
@@ -7,12 +7,12 @@
     this.style.pointerEvents = 'none';
     this.style.userSelect = 'none';
 
-    lastY = (event.clientY || event.clientY === 0) ? event.clientY : event.touches[0].clientY);
+    lastY = (event.clientY || event.clientY === 0) ? event.clientY : event.touches[0].clientY;
   }
 
   function dragMove(event) {
     if (!dragging) return;
-    var clientY = (event.clientY || event.clientY === 0) ? event.clientY : event.touches[0].clientY);
+    var clientY = (event.clientY || event.clientY === 0) ? event.clientY : event.touches[0].clientY;
     this.scrollTop += (clientY - lastY)/this.thumb.scaling;
     lastY = clientY;
     event.preventDefault();

--- a/custom-scrollbar/scrollbar.js
+++ b/custom-scrollbar/scrollbar.js
@@ -1,7 +1,7 @@
 (function(scope) {
   var dragging = false;
   var lastY = 0;
-  
+
   function dragStart(event) {
     dragging = true;
     this.style.pointerEvents = 'none';


### PR DESCRIPTION
|| treats 0 like null, false or undefined, though 0 is a reasonable and valid value to expect.
Changed the condition to explicitly check for the 0 case.

Scenario - drag the thumb so that clientY is 0 (the cursor should be adjacent to the top of the viewport. An exception is thrown because touches[0] do not exist on non-touch devices. Though everything works fine afterwards, exceptions are a real downer.