### PR TITLE
GitHub pages support and better error handling.

### DIFF
--- a/stream-progress/stream.js
+++ b/stream-progress/stream.js
@@ -70,8 +70,13 @@ class JSONTransformer {
 }
 
 const dial = document.querySelector('sc-dial');
-fetch('/tweets.json')
+fetch('./tweets.json')
   .then(async resp => {
+
+    if (resp.status != 200) {
+      //Don't try to parse non JSON responses, such as a 404 error...
+    }
+
     const bytesTotal = parseInt(resp.headers.get('Content-Length'), 10);
     const jsonStream = resp.body.pipeThrough(new TransformStream(new JSONTransformer()));
     const reader = jsonStream.getReader();
@@ -80,7 +85,7 @@ fetch('/tweets.json')
     while(true) {
       const {value, done} = await reader.read();
       if(done) {
-        dial.percentage = 1;i
+        dial.percentage = 1;
         return;
       }
 


### PR DESCRIPTION
Running this sample currently fails on GitHub pages because the `tweets.json` file is loaded from an absolute path, when it should be relative. I have changed this.

I also noticed that this wasn't handled very well, and so although this shouldn't really be a problem, I have added a quick 200 status check to prevent the transformer parsing non JSON pages.

Finally, I removed a rogue `i` hiding in the code for when the request has completed.

Keep up the awesome work! Hoping to see more Supercharged videos soon.