### PR TITLE
Clip animation without between-frame artifacts

### DIFF
--- a/animated-clip/index.html
+++ b/animated-clip/index.html
@@ -28,15 +28,21 @@ limitations under the License.
       pointer-events: none;
       transform-origin: top left;
       overflow: hidden;
+      contain: content;
       border-radius: 3px;
       box-shadow: 0 3px 3px rgba(0, 0, 0, 0.4);
       background: #FFF;
       will-change: transform;
+      animation-duration: 200ms;
+      animation-timing-function: step-end;
     }
 
     .menu__contents {
       transform-origin: top left;
       will-change: transform;
+      contain: content;
+      animation-duration: 200ms;
+      animation-timing-function: step-end;
     }
 
     .menu__toggle {
@@ -78,26 +84,18 @@ limitations under the License.
 
     .menu--expanded {
       animation-name: menuExpandAnimation;
-      animation-duration: 0.2s;
-      animation-timing-function: linear;
     }
 
     .menu__contents--expanded {
       animation-name: menuExpandContentsAnimation;
-      animation-duration: 0.2s;
-      animation-timing-function: linear;
     }
 
     .menu--collapsed {
       animation-name: menuCollapseAnimation;
-      animation-duration: 0.2s;
-      animation-timing-function: linear;
     }
 
     .menu__contents--collapsed {
       animation-name: menuCollapseContentsAnimation;
-      animation-duration: 0.2s;
-      animation-timing-function: linear;
     }
 
   </style>

--- a/animated-clip/menu.js
+++ b/animated-clip/menu.js
@@ -28,6 +28,7 @@ class Menu {
     this._animate = false;
     this._duration = 200;
     this._frameTime = 1/60;
+    this._nFrames = Math.round(this._duration / this._frameTime);
     this._collapsed;
 
     this.expand = this.expand.bind(this);
@@ -131,8 +132,6 @@ class Menu {
     if (menuEase) {
       return menuEase;
     }
-
-    this._nFrames = Math.round(this._duration / this._frameTime);
 
     menuEase = document.createElement('style');
     menuEase.classList.add('menu-ease');

--- a/animated-clip/menu.js
+++ b/animated-clip/menu.js
@@ -198,41 +198,41 @@ class Menu {
   }
 
   _append ({
-    percentage,
-    step,
-    startX,
-    startY,
-    endX,
-    endY,
-    outerAnimation,
-    innerAnimation}=opts) {
+        percentage,
+        step,
+        startX,
+        startY,
+        endX,
+        endY,
+        outerAnimation,
+        innerAnimation}=opts) {
 
-      const xScale = (startX + (endX - startX) * step).toFixed(5);
-      const yScale = (startY + (endY - startY) * step).toFixed(5);
+    const xScale = (startX + (endX - startX) * step).toFixed(5);
+    const yScale = (startY + (endY - startY) * step).toFixed(5);
 
-      const invScaleX = (1 / xScale).toFixed(5);
-      const invScaleY = (1 / yScale).toFixed(5);
+    const invScaleX = (1 / xScale).toFixed(5);
+    const invScaleY = (1 / yScale).toFixed(5);
 
-      outerAnimation.push(`
+    outerAnimation.push(`
       ${percentage}% {
         transform: scale(${xScale}, ${yScale});
       }`);
 
-      innerAnimation.push(`
+    innerAnimation.push(`
       ${percentage}% {
         transform: scale(${invScaleX}, ${invScaleY});
       }`);
-    }
-
-    _clamp (value, min, max) {
-      return Math.max(min, Math.min(max, value));
-    }
-
-    _ease (v, pow=4) {
-      v = this._clamp(v, 0, 1);
-
-      return 1 - Math.pow(1 - v, pow);
-    }
   }
 
-  new Menu()
+  _clamp (value, min, max) {
+    return Math.max(min, Math.min(max, value));
+  }
+
+  _ease (v, pow=4) {
+    v = this._clamp(v, 0, 1);
+
+    return 1 - Math.pow(1 - v, pow);
+  }
+}
+
+new Menu()

--- a/animated-clip/menu.js
+++ b/animated-clip/menu.js
@@ -26,25 +26,20 @@ class Menu {
 
     this._expanded = true;
     this._animate = false;
-    this._duration;
-    this._refreshRate;
-    this._frameTime;
+    this._duration = 200;
+    this._frameTime = 1/60;
     this._collapsed;
 
     this.expand = this.expand.bind(this);
     this.collapse = this.collapse.bind(this);
     this.toggle = this.toggle.bind(this);
 
-    // promisify to give it some breathing space
-    this._getRefreshRate()
-      .then(_ => {
-        this._calculateScales();
-        this._createEaseAnimations();
-        this._addEventListeners();
+    this._calculateScales();
+    this._createEaseAnimations();
+    this._addEventListeners();
 
-        this.collapse();
-        this.activate();
-    });
+    this.collapse();
+    this.activate();
 
   }
 
@@ -98,27 +93,6 @@ class Menu {
     this.expand();
   }
 
-  _getRefreshRate() {
-    const rafPromise = _ => new Promise(window.requestAnimationFrame);
-    const idlePromise = _ => new Promise(window.requestIdleCallback);
-
-    let f1, f2;
-
-    return new Promise(resolve => {
-      idlePromise()
-      .then(_ => rafPromise())
-      .then(_ => rafPromise())
-      .then(frame => {f1 = frame; return rafPromise();})
-      .then(frame => {f2 = frame; return rafPromise();})
-      .then(_ => {
-        this._frameTime = f2 - f1;
-        this._refreshRate = Math.round(1000 / this._frameTime);
-        console.log(`Refresh rate should be ${this._refreshRate}Hz`);
-        resolve();
-      });
-    });
-  }
-
   _addEventListeners () {
     this._menuToggleButton.addEventListener('click', this.toggle);
   }
@@ -158,10 +132,7 @@ class Menu {
       return menuEase;
     }
 
-    this._duration = window.getComputedStyle(this._menu).animationDuration
-      .slice(0, -1) * 1000;
     this._nFrames = Math.round(this._duration / this._frameTime);
-    console.log(`Total of ${this._nFrames} frames`);
 
     menuEase = document.createElement('style');
     menuEase.classList.add('menu-ease');


### PR DESCRIPTION
A followup on https://twitter.com/ChromiumDev/status/845402027362521088

I added 2 raf-s to figure out the refresh rate of the device in order to accomodate varying refresh rates. It's wrapped in a `requestIdleCallback` and promisified to give the thread breathing room for accurate detection.
The animation is then defined per frame and uses `animation-timing-function: step-end` to only render the those needed.

In theory, this approach _should_ not cause mid-frame artifacts, generates ~1/10th of the frames for usual ~200-ish durations and is a bit fancier. Should be easier processing wise as well.