### PR TITLE
FIX: Now actually using the declared consts

### DIFF
--- a/animated-clip/menu.js
+++ b/animated-clip/menu.js
@@ -155,10 +155,10 @@ class Menu {
       this._append({
         percentage,
         step,
-        startX: this._collapsed.x,
-        startY: this._collapsed.y,
-        endX: 1,
-        endY: 1,
+        startX,
+        startY,
+        endX,
+        endY,
         outerAnimation: menuExpandAnimation,
         innerAnimation: menuExpandContentsAnimation
       });


### PR DESCRIPTION
Just a tiny clean-up. Keeps eslint from yelling at unused variables.

Instead of doing this, one might want to remove the consts and keep the function call as is. Otherwise, the next function call might seem a bit confusing.